### PR TITLE
fix: Add minification of htmlcs.js

### DIFF
--- a/core/jobs/build.gradle.kts
+++ b/core/jobs/build.gradle.kts
@@ -1,8 +1,13 @@
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+import org.gradlewebtools.minify.JsMinifyTask;
+
 plugins {
     id("com.cognifide.aet.java-conventions")
     id("com.cognifide.aet.test-coverage")
     id("biz.aQute.bnd.builder")
+    id("org.gradlewebtools.minify") version "1.1.0"
 }
+
 
 dependencies {
     testImplementation("junit:junit:4.13.1")
@@ -33,6 +38,18 @@ dependencies {
     projectCompile(project(":proxy"))
     projectCompile(project(":selenium"))
     projectCompile(project(":w3chtml5validator"))
+}
+
+tasks.register<JsMinifyTask>("minifyHtmlcs") {
+    srcDir = project.file("src/main/resources/collectors/accessibility")
+    dstDir = project.file("${buildDir}/resources/main/collectors/accessibility")
+    options {
+        languageOut = LanguageMode.ECMASCRIPT5
+    }
+}
+
+tasks.processResources {
+    dependsOn(tasks["minifyHtmlcs"])
 }
 
 tasks.jar {

--- a/core/jobs/src/main/resources/collectors/accessibility/htmlcs.js
+++ b/core/jobs/src/main/resources/collectors/accessibility/htmlcs.js
@@ -21,7 +21,7 @@
 * added HTMLCS.getMessagesJSON()
 * wrapped everything in IIFE to fix minifier syntax errors
 */
-(function(arguments){
+(function(args){
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         define(['htmlcs'], factory);
@@ -7840,6 +7840,6 @@ var Runner = function () {
 }();
 
 var HTMLCS_RUNNER = new Runner();
-HTMLCS.process(arguments[0], window.document);
+HTMLCS.process(args[0], window.document);
 return HTMLCS.getMessagesJSON();
 })(arguments);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minified version of htmlcs.js is what the accessibility bundle is trying to find. After the migration to gradle, the minified version wasn't being created during the build and because of that it breaks the accessibility comparator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] I have reviewed (and updated if needed) the documentation regarding this change

---
I hereby agree to the terms of the AET Contributor License Agreement.
